### PR TITLE
Bump CSSJanus dependancy to v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "cssjanus" : ">=1.0.2"
+    "cssjanus" : ">=1.1.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
See https://buddypress.trac.wordpress.org/ticket/6104 and https://core.trac.wordpress.org/ticket/30997

Yoavf, would be cool if you could take a look at bumping the dependancy per r-a-y's suggestion in #4 please :)